### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/unmatched78/CycleSync/security/code-scanning/1](https://github.com/unmatched78/CycleSync/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Since the workflow only performs read operations (e.g., checking out code, setting up Python, installing dependencies, and running pylint), the `contents: read` permission is sufficient. This change ensures that the workflow has the minimal permissions required to function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
